### PR TITLE
fix: remove some UB - writing into a shared reference

### DIFF
--- a/src/sha256_intrinsics.rs
+++ b/src/sha256_intrinsics.rs
@@ -262,6 +262,6 @@ pub unsafe fn compress256(state: &mut [u32; 8], block: &[u8; 64]) {
     state1 = _mm_alignr_epi8(state1, tmp, 8); // ABEF
 
     // Save state
-    _mm_storeu_si128(state.as_ptr().add(0) as *mut __m128i, state0);
-    _mm_storeu_si128(state.as_ptr().add(4) as *mut __m128i, state1);
+    _mm_storeu_si128(state.as_mut_ptr().add(0) as *mut __m128i, state0);
+    _mm_storeu_si128(state.as_mut_ptr().add(4) as *mut __m128i, state1);
 }


### PR DESCRIPTION
`as_ptr` creates the raw pointer from a shared reference, so writing into it is UB
https://doc.rust-lang.org/std/primitive.slice.html#method.as_ptr

`as_mut_ptr` creates it from a unique reference, so you can freely write into it.

(and maybe consider replacing `4` with some constant that depends on `size_of::<__m128i>()` like: https://play.rust-lang.org/?gist=ccc600e9aec4866a066fc3484c9f2cba)