### PR TITLE
chore: add note that upstream supports SHA-NI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://docs.rs/sha2ni)
 > Sha2 implemention in Rust, aimed at performance. 
 > Forked from [Sha2](https://github.com/rustcrypto/hashes).
 
+This fork is no longer needed as the upstream [`sha2` crate](https://crates.io/crates/sha2) now supports the SHA-NI extension.
 
 ## License
 


### PR DESCRIPTION
Add a note to the README that this fork is no longer needed, as the upstream sha2 crate not supports the SHA-NI extension.